### PR TITLE
Test '--dec' mode as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,12 @@ test:	$(EXE)
 	[ $$((size%8)) = 0 ] && size=; \
 	for mode in uint8 uint16 uint32 uint64 int8 int16 int32 int64; do \
 		echo "Testing C $$mode mode" 1>&2; \
-		./$(EXE) --c-$$mode --file $(EXE) > test.$$mode.c; \
-		$(CC) --include stdint.h -c test.$$mode.c -o test.$$mode.o; \
-		$(OBJCOPY) --output-target binary test.$$mode.o; \
-		[ -n "$$size" ] && truncate -s $$size test.$$mode.o; \
-		cmp $(EXE) test.$$mode.o; \
-		rm -f test.$$mode.c test.$$mode.o; \
+		for base in "" --dec; do \
+			./$(EXE) --c-$$mode $$base --file $(EXE) > test.c; \
+			$(CC) --include stdint.h -c test.c -o test.o; \
+			$(OBJCOPY) --output-target binary test.o; \
+			[ -n "$$size" ] && truncate -s $$size test.o; \
+			cmp $(EXE) test.o; \
+			rm -f test.c test.o; \
+		done; \
 	done


### PR DESCRIPTION
This change adds tests for outputs generated using the `--dec` option.